### PR TITLE
Update BridgeAuth.php

### DIFF
--- a/BridgeAuth/src/EPICMC/BridgeAuth/BridgeAuth.php
+++ b/BridgeAuth/src/EPICMC/BridgeAuth/BridgeAuth.php
@@ -51,8 +51,8 @@ class BridgeAuth extends PluginBase implements Listener{
      */
 	public function onJoin(PlayerJoinEvent $event){
 		$player = $event->getPlayer();
-		$player->sendMessage(self::PREFIX . 'This server utilizes BridgeAuth to handle authentication.');
-		$player->sendMessage('Enter your bridge token into chat to play, or visit bridge.epicmc.us online to generate one.');
+		$player->sendMessage(TextFormat::GREEN . self::PREFIX . TextFormat::WHITE . 'This server utilizes BridgeAuth to handle authentication.');
+		$player->sendMessage('Enter your bridge token into chat to play, or visit . TextFormat::DARK_BLUE . TextFormat::UNDERLINE . bridge.epicmc.us . TextFormat::RESET . online to generate one.');
 	}
 
     public function authComplete($name, $result){
@@ -62,8 +62,8 @@ class BridgeAuth extends PluginBase implements Listener{
 				if($result === true){
 					$this->authPlayer($player);
 				}else{
-					$player->sendMessage(self::PREFIX . 'Authentication Failure! Either the token you entered is incorrect, or maybe IP checking is enabled and your IP has changed.');
-					$player->sendMessage('Visit bridge.epicmc.us online for more info.');
+					$player->sendMessage(TextFormat::GREEN . self::PREFIX . TextFormat::WHITE . 'Authentication Failure! Either the token you entered is incorrect, or maybe IP checking is enabled and your IP has changed.');
+					$player->sendMessage('Visit . TextFormat::DARK_BLUE . bridge.epicmc.us . TextFormat::RESET . online for more info.');
 				}
 			}
         }else{


### PR DESCRIPTION
TextFormat::RESET should work to reset the message to its original unedited state but it might not I'm not sure.  I checked the source code and it looks like that's what it does.